### PR TITLE
Remove SetFilterFilterCoefficientSet when adding SetTxFilterCoefficientSet

### DIFF
--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -78,8 +78,8 @@ const char* vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_FNUMBER       = "SetBTran
 const char* vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_FNUMBER       = "GetBTransmitFNumber";
 const char* vtkPlusWinProbeVideoSource::SET_B_APODIZATION_FNUMBER        = "SetBApodizationFNumber";
 const char* vtkPlusWinProbeVideoSource::GET_B_APODIZATION_FNUMBER        = "GetBApodizationFNumber";
-const char* vtkPlusWinProbeVideoSource::SET_B_FILTER_COEFFICIENT_SET = "SetBFilterCoefficientSet";
-const char* vtkPlusWinProbeVideoSource::GET_B_FILTER_COEFFICIENT_SET = "GetBFilterCoefficientSet";
+const char* vtkPlusWinProbeVideoSource::SET_B_TX_FILTER_COEFFICIENT_SET = "SetBTXFilterCoefficientSet";
+const char* vtkPlusWinProbeVideoSource::GET_B_TX_FILTER_COEFFICIENT_SET = "GetBTXFilterCoefficientSet";
 const char* vtkPlusWinProbeVideoSource::GET_TRANSDUCER_INTERNAL_ID   = "GetTransducerInternalID";
 const char* vtkPlusWinProbeVideoSource::SET_ARFI_ENABLED             = "SetARFIEnabled";
 const char* vtkPlusWinProbeVideoSource::GET_ARFI_ENABLED             = "GetARFIEnabled";
@@ -1871,23 +1871,22 @@ double vtkPlusWinProbeVideoSource::GetBApodizationFNumber()
   return m_BApodizationFNumber;
 }
 
-void vtkPlusWinProbeVideoSource::SetBFilterCoefficientSet(uint8_t value)
+void vtkPlusWinProbeVideoSource::SetBTXFilterCoefficientSet(int32_t value)
 {
   if(Connected)
   {
-    SetFilterFilterCoefficientSet(value);
-    SetPendingRecreateTables(true);
+    SetTxFilterCoefficientSet(value);
   }
-  m_BFilterCoefficientSet = GetBFilterCoefficientSet();
+  m_BTXFilterCoefficientSet = GetTxFilterCoefficientSet();
 }
 
-uint8_t vtkPlusWinProbeVideoSource::GetBFilterCoefficientSet()
+int32_t vtkPlusWinProbeVideoSource::GetBTXFilterCoefficientSet()
 {
   if(Connected)
   {
-    m_BFilterCoefficientSet = GetFilterFilterCoefficientSet();
+    m_BTXFilterCoefficientSet = GetTxFilterCoefficientSet();
   }
-  return m_BFilterCoefficientSet;
+  return m_BTXFilterCoefficientSet;
 }
 
 bool vtkPlusWinProbeVideoSource::GetMModeEnabled()

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -519,8 +519,18 @@ void vtkPlusWinProbeVideoSource::FrameCallback(int length, char* data, char* hHe
   }
   else if(usMode & BFRFALineImage_RFData)
   {
+    int harmonic_multiplier = 1;  // RF data contains more lines when the harmonic flags are turned on because it includes data for each transmit
+    if (m_BHarmonicEnabled & (m_BBubbleContrastEnabled || m_BAmplitudeModulationEnabled))
+    {
+      harmonic_multiplier = 3;
+    }
+    else if (m_BHarmonicEnabled & !m_BBubbleContrastEnabled & !m_BAmplitudeModulationEnabled)
+    {
+      harmonic_multiplier = 2;
+    }
+
     frameSize[0] = brfGeometry->SamplesPerLine * brfGeometry->Decimation;
-    frameSize[1] = brfGeometry->LineCount;
+    frameSize[1] = brfGeometry->LineCount * harmonic_multiplier;
     if(frameSize != m_ExtraSources[0]->GetInputFrameSize())
     {
       LOG_INFO("Rf frame size updated. Adjusting buffer size and spacing.");

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.cxx
@@ -60,6 +60,7 @@ const char* vtkPlusWinProbeVideoSource::SET_M_DEPTH                  = "SetMDept
 const char* vtkPlusWinProbeVideoSource::GET_M_DEPTH                  = "GetMDepth";
 const char* vtkPlusWinProbeVideoSource::SET_DECIMATION               = "SetDecimation";
 const char* vtkPlusWinProbeVideoSource::GET_DECIMATION               = "GetDecimation";
+const char* vtkPlusWinProbeVideoSource::GET_B_PRF                    = "GetBPRF";
 const char* vtkPlusWinProbeVideoSource::SET_B_FRAME_RATE_LIMIT       = "SetBFrameRateLimit";
 const char* vtkPlusWinProbeVideoSource::GET_B_FRAME_RATE_LIMIT       = "GetBFrameRateLimit";
 const char* vtkPlusWinProbeVideoSource::SET_B_HARMONIC_ENABLED       = "SetBHarmonicEnabled";
@@ -78,6 +79,10 @@ const char* vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_FNUMBER       = "SetBTran
 const char* vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_FNUMBER       = "GetBTransmitFNumber";
 const char* vtkPlusWinProbeVideoSource::SET_B_APODIZATION_FNUMBER        = "SetBApodizationFNumber";
 const char* vtkPlusWinProbeVideoSource::GET_B_APODIZATION_FNUMBER        = "GetBApodizationFNumber";
+const char* vtkPlusWinProbeVideoSource::SET_B_BUBBLE_DESTRUCTION_ENABLED = "SetBBubbleDestructionEnabled";
+const char* vtkPlusWinProbeVideoSource::GET_B_BUBBLE_DESTRUCTION_ENABLED = "GetBBubbleDestructionEnabled";
+const char* vtkPlusWinProbeVideoSource::SET_B_BUBBLE_DESTRUCTION_CYCLE_COUNT = "SetBBubbleDestructionCycleCount";
+const char* vtkPlusWinProbeVideoSource::GET_B_BUBBLE_DESTRUCTION_CYCLE_COUNT = "GetBBubbleDestructionCycleCount";
 const char* vtkPlusWinProbeVideoSource::SET_B_TX_FILTER_COEFFICIENT_SET = "SetBTXFilterCoefficientSet";
 const char* vtkPlusWinProbeVideoSource::GET_B_TX_FILTER_COEFFICIENT_SET = "GetBTXFilterCoefficientSet";
 const char* vtkPlusWinProbeVideoSource::GET_TRANSDUCER_INTERNAL_ID   = "GetTransducerInternalID";
@@ -976,6 +981,8 @@ PlusStatus vtkPlusWinProbeVideoSource::InternalConnect()
   this->SetBTransmitCycleCount(m_BTransmitCycleCount);
   this->SetBTransmitFNumber(m_BTransmitFNumber);
   this->SetBApodizationFNumber(m_BApodizationFNumber);
+  this->SetBBubbleDestructionEnabled(m_BBubbleDestructionEnabled);
+  this->SetBBubbleDestructionCycleCount(m_BBubbleDestructionCycleCount);
 
   //setup size for DirectX image
   LOG_DEBUG("Setting output size to " << m_PrimaryFrameSize[0] << "x" << m_PrimaryFrameSize[1]);
@@ -1871,6 +1878,43 @@ double vtkPlusWinProbeVideoSource::GetBApodizationFNumber()
   return m_BApodizationFNumber;
 }
 
+void vtkPlusWinProbeVideoSource::SetBBubbleDestructionEnabled(bool value)
+{
+  if(Connected)
+  {
+    SetBisBubblePop(value);
+  }
+  m_BBubbleDestructionEnabled = GetBisBubblePop();
+}
+
+bool vtkPlusWinProbeVideoSource::GetBBubbleDestructionEnabled()
+{
+  if(Connected)
+  {
+    m_BBubbleDestructionEnabled = GetBisBubblePop();
+  }
+  return m_BBubbleDestructionEnabled;
+}
+
+void vtkPlusWinProbeVideoSource::SetBBubbleDestructionCycleCount(int16_t value)
+{
+  if(Connected)
+  {
+    SetTxBubblePopCycleCount(value);
+    SetPendingRecreateTables(true);
+  }
+  m_BBubbleDestructionCycleCount = GetTxBubblePopCycleCount();
+}
+
+int16_t vtkPlusWinProbeVideoSource::GetBBubbleDestructionCycleCount()
+{
+  if(Connected)
+  {
+    m_BBubbleDestructionCycleCount = GetTxBubblePopCycleCount();
+  }
+  return m_BBubbleDestructionCycleCount;
+}
+
 void vtkPlusWinProbeVideoSource::SetBTXFilterCoefficientSet(int32_t value)
 {
   if(Connected)
@@ -2339,6 +2383,15 @@ PlusStatus vtkPlusWinProbeVideoSource::ARFIPush(uint8_t maximumVoltage /* = 50 *
 std::string vtkPlusWinProbeVideoSource::GetTransducerID()
 {
   return this->m_TransducerID;
+}
+
+int vtkPlusWinProbeVideoSource::GetBPRF()
+{
+  if (Connected)
+  {
+    m_BPRF = ::GetBPRF();
+  }
+  return m_BPRF;
 }
 
 void vtkPlusWinProbeVideoSource::SetBFrameRateLimit(int32_t value)

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -68,6 +68,7 @@ public:
   static const char* GET_M_DEPTH;
   static const char* SET_DECIMATION;
   static const char* GET_DECIMATION;
+  static const char* GET_B_PRF;
   static const char* SET_B_FRAME_RATE_LIMIT;
   static const char* GET_B_FRAME_RATE_LIMIT;
   static const char* SET_B_HARMONIC_ENABLED;
@@ -86,6 +87,10 @@ public:
   static const char* GET_B_TRANSMIT_FNUMBER;
   static const char* SET_B_APODIZATION_FNUMBER;
   static const char* GET_B_APODIZATION_FNUMBER;
+  static const char* SET_B_BUBBLE_DESTRUCTION_ENABLED;
+  static const char* GET_B_BUBBLE_DESTRUCTION_ENABLED;
+  static const char* SET_B_BUBBLE_DESTRUCTION_CYCLE_COUNT;
+  static const char* GET_B_BUBBLE_DESTRUCTION_CYCLE_COUNT;
   static const char* SET_B_TX_FILTER_COEFFICIENT_SET;
   static const char* GET_B_TX_FILTER_COEFFICIENT_SET;
   static const char* GET_TRANSDUCER_INTERNAL_ID;
@@ -331,6 +336,12 @@ public:
   void SetBApodizationFNumber(double value);
   double GetBApodizationFNumber();
 
+  void SetBBubbleDestructionEnabled(bool value);
+  bool GetBBubbleDestructionEnabled();
+
+  void SetBBubbleDestructionCycleCount(int16_t value);
+  int16_t GetBBubbleDestructionCycleCount();
+
   void SetBTXFilterCoefficientSet(int32_t value);   // set actual filter number
   int32_t GetBTXFilterCoefficientSet();
 
@@ -360,6 +371,8 @@ public:
 
   void SetMDepth(int32_t value);
   int32_t GetMDepth();
+
+  int GetBPRF();
 
   void SetBFrameRateLimit(int32_t value);
   int32_t GetBFrameRateLimit();
@@ -562,6 +575,7 @@ protected:
   int32_t m_MDepth = 0;
   uint8_t m_SSDecimation = 2;
   double m_FirstGainValue = 15;
+  int m_BPRF = 0;
   int32_t m_BFrameRateLimit = 0;
   bool m_BHarmonicEnabled = false;
   bool m_BBubbleContrastEnabled = false;
@@ -571,6 +585,8 @@ protected:
   uint16_t m_BTransmitCycleCount = 2;
   double m_BTransmitFNumber = 3;
   double m_BApodizationFNumber = 0.5;
+  bool m_BBubbleDestructionEnabled = false;
+  int16_t m_BBubbleDestructionCycleCount = 12;
   int32_t m_BTXFilterCoefficientSet = 3;      // default filter
   std::vector<vtkPlusDataSource*> m_PrimarySources;
   std::vector<vtkPlusDataSource*> m_ExtraSources;

--- a/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
+++ b/src/PlusDataCollection/WinProbe/vtkPlusWinProbeVideoSource.h
@@ -86,8 +86,8 @@ public:
   static const char* GET_B_TRANSMIT_FNUMBER;
   static const char* SET_B_APODIZATION_FNUMBER;
   static const char* GET_B_APODIZATION_FNUMBER;
-  static const char* SET_B_FILTER_COEFFICIENT_SET;
-  static const char* GET_B_FILTER_COEFFICIENT_SET;
+  static const char* SET_B_TX_FILTER_COEFFICIENT_SET;
+  static const char* GET_B_TX_FILTER_COEFFICIENT_SET;
   static const char* GET_TRANSDUCER_INTERNAL_ID;
   static const char* SET_ARFI_ENABLED;
   static const char* GET_ARFI_ENABLED;
@@ -331,8 +331,8 @@ public:
   void SetBApodizationFNumber(double value);
   double GetBApodizationFNumber();
 
-  void SetBFilterCoefficientSet(uint8_t value);
-  uint8_t GetBFilterCoefficientSet();
+  void SetBTXFilterCoefficientSet(int32_t value);   // set actual filter number
+  int32_t GetBTXFilterCoefficientSet();
 
   void SetBRFEnabled(bool value);
   bool GetBRFEnabled();
@@ -571,7 +571,7 @@ protected:
   uint16_t m_BTransmitCycleCount = 2;
   double m_BTransmitFNumber = 3;
   double m_BApodizationFNumber = 0.5;
-  uint8_t m_BFilterCoefficientSet = 3;
+  int32_t m_BTXFilterCoefficientSet = 3;      // default filter
   std::vector<vtkPlusDataSource*> m_PrimarySources;
   std::vector<vtkPlusDataSource*> m_ExtraSources;
 

--- a/src/PlusServer/Commands/vtkPlusWinProbeCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusWinProbeCommand.cxx
@@ -282,7 +282,7 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_CYCLE_COUNT)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_FNUMBER)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_APODIZATION_FNUMBER)
-        || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_FILTER_COEFFICIENT_SET)
+        || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TX_FILTER_COEFFICIENT_SET)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_TRANSDUCER_INTERNAL_ID)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_ENABLED)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_START_SAMPLE)
@@ -356,8 +356,8 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
           res = std::to_string(device->GetBTransmitFNumber());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_APODIZATION_FNUMBER))
           res = std::to_string(device->GetBApodizationFNumber());
-      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_FILTER_COEFFICIENT_SET))
-          res = std::to_string(device->GetBFilterCoefficientSet());
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TX_FILTER_COEFFICIENT_SET))
+          res = std::to_string(device->GetBTXFilterCoefficientSet());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_TRANSDUCER_INTERNAL_ID))
           res = std::to_string(device->GetTransducerInternalID());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_ENABLED))
@@ -435,6 +435,7 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_FNUMBER)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_APODIZATION_FNUMBER)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_FILTER_COEFFICIENT_SET)
+             || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TX_FILTER_COEFFICIENT_SET)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_ENABLED)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_START_SAMPLE)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_STOP_SAMPLE)
@@ -609,10 +610,10 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
         device->SetBApodizationFNumber(val);
         status = PLUS_SUCCESS;
       }
-      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_FILTER_COEFFICIENT_SET))
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TX_FILTER_COEFFICIENT_SET))
       {
-        uint8_t val = stod(value);
-        device->SetBFilterCoefficientSet(val);
+        int32_t val = stod(value);
+        device->SetBTXFilterCoefficientSet(val);
         status = PLUS_SUCCESS;
       }
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_ENABLED))

--- a/src/PlusServer/Commands/vtkPlusWinProbeCommand.cxx
+++ b/src/PlusServer/Commands/vtkPlusWinProbeCommand.cxx
@@ -273,6 +273,7 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_M_WIDTH)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_M_DEPTH)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_DECIMATION)
+        || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_PRF)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_FRAME_RATE_LIMIT)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_HARMONIC_ENABLED)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_BUBBLE_CONTRAST_ENABLED)
@@ -282,6 +283,8 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_CYCLE_COUNT)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TRANSMIT_FNUMBER)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_APODIZATION_FNUMBER)
+        || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_BUBBLE_DESTRUCTION_ENABLED)
+        || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_BUBBLE_DESTRUCTION_CYCLE_COUNT)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TX_FILTER_COEFFICIENT_SET)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_TRANSDUCER_INTERNAL_ID)
         || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_ARFI_ENABLED)
@@ -340,6 +343,8 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
           res = std::to_string(device->GetSSDecimation());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_FRAME_RATE_LIMIT))
           res = std::to_string(device->GetBFrameRateLimit());
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_PRF))
+          res = std::to_string(device->GetBPRF());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_HARMONIC_ENABLED))
           res = device->GetBHarmonicEnabled() ? "True" : "False";
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_BUBBLE_CONTRAST_ENABLED))
@@ -356,6 +361,10 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
           res = std::to_string(device->GetBTransmitFNumber());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_APODIZATION_FNUMBER))
           res = std::to_string(device->GetBApodizationFNumber());
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_BUBBLE_DESTRUCTION_ENABLED))
+          res = device->GetBBubbleDestructionEnabled() ? "True" : "False";
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_BUBBLE_DESTRUCTION_CYCLE_COUNT))
+          res = std::to_string(device->GetBBubbleDestructionCycleCount());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_B_TX_FILTER_COEFFICIENT_SET))
           res = std::to_string(device->GetBTXFilterCoefficientSet());
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::GET_TRANSDUCER_INTERNAL_ID))
@@ -434,6 +443,8 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_CYCLE_COUNT)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TRANSMIT_FNUMBER)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_APODIZATION_FNUMBER)
+             || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_BUBBLE_DESTRUCTION_ENABLED)
+             || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_BUBBLE_DESTRUCTION_CYCLE_COUNT)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_FILTER_COEFFICIENT_SET)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TX_FILTER_COEFFICIENT_SET)
              || igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_ARFI_ENABLED)
@@ -608,6 +619,18 @@ PlusStatus vtkPlusWinProbeCommand::Execute()
       {
         double val = stod(value);
         device->SetBApodizationFNumber(val);
+        status = PLUS_SUCCESS;
+      }
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_BUBBLE_DESTRUCTION_ENABLED))
+      {
+        bool set = igsioCommon::IsEqualInsensitive(value, "true") ? true : false;
+        device->SetBBubbleDestructionEnabled(set);
+        status = PLUS_SUCCESS;
+      }
+      else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_BUBBLE_DESTRUCTION_CYCLE_COUNT))
+      {
+        uint8_t val = stod(value);
+        device->SetBBubbleDestructionCycleCount(val);
         status = PLUS_SUCCESS;
       }
       else if (igsioCommon::IsEqualInsensitive(parameterName, vtkPlusWinProbeVideoSource::SET_B_TX_FILTER_COEFFICIENT_SET))


### PR DESCRIPTION
This is based on https://github.com/jrojasUNC/PlusLib/tree/juanrojas-add-new-winprobe-commands but is a force-pushed variant which removes `SetFilterFilterCoefficientSet` to be replaced by `SetTxFilterCoefficientSet`. I did not have rights to update this branch directly which is why I have posted this PR. cc: @jrojasUNC 